### PR TITLE
Fix issue where drag-and-drop does not work on Linux

### DIFF
--- a/src/gui/dialogs/files/DragDropLabel.py
+++ b/src/gui/dialogs/files/DragDropLabel.py
@@ -33,7 +33,7 @@ class DragDropLabel(QLabel):
 
     def dropEvent(self, event: QDropEvent) -> None:
         """Called when a drop event occurs."""
-        file_path = event.mimeData().text()
+        file_path = event.mimeData().text().rstrip()
         if self.drop_callback:
             self.drop_callback(file_path)
 


### PR DESCRIPTION
Fixes #5 

On some Linux desktop environments, such as GNOME, the text received from a drag-and-drop event ends in `\r\n`. This caused problems loading a data file.